### PR TITLE
don't use __del__, call it manually

### DIFF
--- a/smach_ros/smach_ros/introspection.py
+++ b/smach_ros/smach_ros/introspection.py
@@ -29,7 +29,7 @@ class IntrospectionClient(Node):
         self._spinner = threading.Thread(target=self._executor.spin)
         self._spinner.start()
 
-    def __del__(self):
+    def shutdown(self):
         self._executor.shutdown()
         self._spinner.join()
 
@@ -282,7 +282,7 @@ class IntrospectionServer(Node):
         self._spinner = threading.Thread(target=self._executor.spin)
         self._spinner.start()
 
-    def __del__(self):
+    def shutdown(self):
         self._executor.shutdown()
         self._spinner.join()
 


### PR DESCRIPTION
Using `__del__` to stop the executor and wait for the thread is seen as bad practice and _(The only required property of Python garbage collection is that it happens after all references have been deleted, so this might not necessarily happen right after and might not happen at all.)_ does_ not work most of the time. I encountered that this node's spin() thread was never cleanly terminated. When calling the renamed shutdown() now (without an exception), the spin() thread can finish cleanly.

This DOES require manually calling the shutdown() method wherever you want to shutdown this node. So after approval of this method, I should rewrite the tests that use this Class.

Another way is to pass a Node to the IntrospectionServer() and IntrospectionClient() classes so they don't make new SingleThreadedExecutors. In this way, even exceptions can be handled better I think.

Another way is maybe to make the spin() thread a Daemon thread, but this resulted in the following error codes/ warnings while running the executive:

```
terminate called without an active exception
[ros2run]: Aborted
```
